### PR TITLE
Fix: use the conventions from PHP

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Hash;
 use App\Models\User;
@@ -12,10 +13,13 @@ class ClientController extends Controller
 {
     /**
      * Display a listing of the resource.
+     * 
+     * This function retrieves and returns all clients available in the system.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse  A JSON response containing the list of clients if successful.
+     *                                      - If there are no clients available, the 'data' field will be an empty array.
      */
-    public function index()
+    public function index(): JsonResponse
     {
         // Get clients
         $clients = User::where('role', 'client')->get();
@@ -27,11 +31,14 @@ class ClientController extends Controller
 
     /**
      * Store a newly created resource in storage.
+     * 
+     * This function creates a new client in the system.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request  $request The HTTP request object.
+     * @return \Illuminate\Http\JsonResponse A JSON response containing the newly created client if successful.
+     *                                     - If validation fails, 'success' will be false, and 'errors' will contain the validation errors.
      */
-    public function store(Request $request)
+    public function store(Request $request): JsonResponse
     {
         // Validate request
         $validatorRules = [
@@ -70,11 +77,15 @@ class ClientController extends Controller
 
     /**
      * Display the specified resource.
+     * 
+     * This function retrieves and returns a specific client identified by its ID.
      *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * @param  int  $id The ID of the client to retrieve.
+     * @return \Illuminate\Http\JsonResponse A JSON response containing the client if successful.
+     *                                      - If validation fails for the ID, 'success' will be false, and 'errors' will contain the validation errors.
+     *                                      - If the client with the given ID is not found, 'success' will be false, and 'message' will indicate 'User not found'. 
      */
-    public function show($id)
+    public function show($id): JsonResponse
     {
         // Find user
         $client = User::find($id);
@@ -97,12 +108,16 @@ class ClientController extends Controller
 
     /**
      * Update the specified resource in storage.
+     * 
+     * This function updates a specific client identified by its ID.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request  $request The HTTP request object.
+     * @param  int  $id The ID of the client to update.
+     * @return \Illuminate\Http\JsonResponse A JSON response containing the updated client if successful.
+     *                                      - If validation fails for the ID, 'success' will be false, and 'errors' will contain the validation errors.
+     *                                      - If the client with the given ID is not found, 'success' will be false, and 'message' will indicate 'User not found'.
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, $id): JsonResponse
     {           
         // Find user
         $client = User::find($id);
@@ -148,11 +163,15 @@ class ClientController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     * 
+     * This function deletes a specific client identified by its ID.
      *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * @param  int  $id The ID of the client to delete.
+     * @return \Illuminate\Http\Response A JSON response containing the deleted client if successful.
+     *                                     - If validation fails for the ID, 'success' will be false, and 'errors' will contain the validation errors.  
+     *                                    - If the client with the given ID is not found, 'success' will be false, and 'message' will indicate 'User not found'.
      */
-    public function destroy($id)
+    public function destroy($id): JsonResponse
     {      
         // Find user
         $client = User::find($id);


### PR DESCRIPTION
- Add the conventions for the returning object of the functions. 
- Add more descriptions in the documentation for the endpoints